### PR TITLE
Update indirect rate in set_rate method

### DIFF
--- a/lib/russian_central_bank.rb
+++ b/lib/russian_central_bank.rb
@@ -26,6 +26,7 @@ class Money
 
       def set_rate(from, to, rate)
         @rates[rate_key_for(from, to)] = rate
+        @rates[rate_key_for(to, from)] = 1.0 / rate
       end
 
       def get_rate from, to

--- a/spec/russian_central_bank_spec.rb
+++ b/spec/russian_central_bank_spec.rb
@@ -35,18 +35,34 @@ describe 'RussianCentralBank' do
   end
 
   describe '#get_rate' do
-    before do
-      @bank.flush_rates
-      @bank.add_rate('RUB', 'USD', 0.03)
-      @bank.add_rate('RUB', 'GBP', 0.02)
+    context 'getting dicrect rates' do
+      before do
+        @bank.flush_rates
+        @bank.add_rate('RUB', 'USD', 0.03)
+        @bank.add_rate('RUB', 'GBP', 0.02)
+      end
+
+      it 'should get rate from @rates' do
+        @bank.get_rate('RUB', 'USD').should == 0.03
+      end
+
+      it 'should calculate indirect rates' do
+        @bank.get_rate('USD', 'GBP').should == 0.6666666666666667
+      end
     end
 
-    it 'should get rate from @rates' do
-      @bank.get_rate('RUB', 'USD').should == 0.03
-    end
+    context 'getting indirect rate' do
+      let(:indirect_rate) { 4 }
 
-    it 'should calculate indirect rates' do
-      @bank.get_rate('USD', 'GBP').should == 0.6666666666666667
+      before do
+        @bank.flush_rates
+        @bank.add_rate('RUB', 'USD', 123)
+        @bank.add_rate('USD', 'RUB', indirect_rate)
+      end
+
+      it 'gets indirect rate from the last set' do
+        expect(@bank.get_rate('RUB', 'USD')).to eq(1.0 / indirect_rate)
+      end
     end
   end
 end


### PR DESCRIPTION
Hi! I've found some problem with `set_rate` method. 

For example, I have:

``` ruby
@bank.flush_rates
@bank.add_rate('RUB', 'USD', 10.0)
```

But after that when I update indirect rate:

``` ruby
@bank.add_rate('USD', 'RUB', 0.5)

# expect
@bank.get_rate('RUB', 'USD') # => (1.0 / 0.5) = 2.0
# but still have
@bank.get_rate('RUB', 'USD') # => 10.0
```

To fix it maybe it should update indirect rate too while setting direct rate in method `set_rate`.
