### PR TITLE
Обновление rspec и money

### DIFF
--- a/spec/russian_central_bank_spec.rb
+++ b/spec/russian_central_bank_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe 'RussianCentralBank' do
   before do
     rates_hash = symbolize_keys YAML::load(File.open('spec/support/daily_rates.yml'))
-    allow(Savon::Client).to receive_message_chain(:call, :body => rates_hash)
+    allow_any_instance_of(Savon::Client).to receive_message_chain(:call, :body) { rates_hash }
   end
 
   before :each do
@@ -16,9 +16,9 @@ describe 'RussianCentralBank' do
     end
 
     it 'should update rates from daily rates service' do
-      @bank.rates['RUB_TO_USD'].should == 0.03083678705348332
-      @bank.rates['RUB_TO_EUR'].should == 0.023478587528174305
-      @bank.rates['RUB_TO_JPY'].should == 3.086143524190736
+      expect(@bank.rates['RUB_TO_USD']).to eq(0.03083678705348332)
+      expect(@bank.rates['RUB_TO_EUR']).to eq(0.023478587528174305)
+      expect(@bank.rates['RUB_TO_JPY']).to eq(3.086143524190736)
     end
   end
 
@@ -30,7 +30,7 @@ describe 'RussianCentralBank' do
     it 'should delete all rates' do
       @bank.get_rate('RUB', 'USD')
       @bank.flush_rates
-      @bank.rates.should == {}
+      expect(@bank.store.send(:index)).to be_empty
     end
   end
 
@@ -43,11 +43,11 @@ describe 'RussianCentralBank' do
       end
 
       it 'should get rate from @rates' do
-        @bank.get_rate('RUB', 'USD').should == 0.03
+        expect(@bank.get_rate('RUB', 'USD')).to eq(0.03)
       end
 
       it 'should calculate indirect rates' do
-        @bank.get_rate('USD', 'GBP').should == 0.6666666666666667
+        expect(@bank.get_rate('USD', 'GBP')).to eq(0.6666666666666667)
       end
     end
 
@@ -72,7 +72,7 @@ describe 'RussianCentralBank' do
       end
 
       it "should not update rates" do
-        @bank.should_not_receive(:update_rates)
+        expect(@bank).to_not receive(:update_rates)
         @bank.get_rate('RUB', 'USD')
       end
     end
@@ -87,7 +87,7 @@ describe 'RussianCentralBank' do
         end
 
         it "should update rates" do
-          @bank.should_receive(:update_rates)
+          expect(@bank).to receive(:update_rates)
           @bank.get_rate('RUB', 'USD')
         end
       end
@@ -99,7 +99,7 @@ describe 'RussianCentralBank' do
         end
 
         it "should not update rates" do
-          @bank.should_not_receive(:update_rates)
+          expect(@bank).to_not receive(:update_rates)
           @bank.get_rate('RUB', 'USD')
         end
       end

--- a/spec/russian_central_bank_spec.rb
+++ b/spec/russian_central_bank_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe 'RussianCentralBank' do
   before do
     rates_hash = symbolize_keys YAML::load(File.open('spec/support/daily_rates.yml'))
-    Savon::Client.any_instance.stub_chain(:call, :body).and_return rates_hash
+    allow(Savon::Client).to receive_message_chain(:call, :body => rates_hash)
   end
 
   before :each do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'support/helpers'
 
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
   config.tty = true
 
   config.order = :random


### PR DESCRIPTION
Изменения
--

1. `rspec` выполнялся с ошибкой, поскольку атрибут `color_enabled` потерял актуальность в `rspec 3.0.0.rc1`
1. `rspec` сыпал сообщениями про устаревшие `should`, заменил их на `expect(...)`
1. Пропал `@mutex`, как я понимаю сейчас вместо него `store.transaction`. С такой конструкцией код выглядит элегантнее, но я не уверен, что уместно её применил
1. В дополнение к предыдущему пункту, хранилище котировок переместилось из `@rates` в `@store` (в приватный `store.index`, если быть точным)
1. Небольшие косметические изменения в соответствии с [руководством по оформлению](https://github.com/arbox/ruby-style-guide/blob/master/README-ruRU.md)

Касательно встречающихся `store.send(:index)` - выдергивание приватных данных мне кажется некрасивым решением, но такой костыль сохраняет неизменность интерфейса. До версии 1.0.0 [можно](http://semver.org) модифицировать программный интерфейс на свой вкус, но конечное слово за автором.

Я пока не уверен, что в этом запросе на слияние всё правильно.

Выполнение тестирования до слияния
--

```
$ rspec
/home/sli/russian_central_bank/spec/spec_helper.rb:7:in `block in <top (required)>': undefined method `color_enabled=' for #<RSpec::Core::Configuration:0x00000001534430> (NoMethodError)
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core.rb:97:in `configure'
	from /home/sli/russian_central_bank/spec/spec_helper.rb:6:in `<top (required)>'
	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/sli/russian_central_bank/spec/russian_central_bank_spec.rb:1:in `<top (required)>'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `each'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:102:in `setup'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
	from /var/lib/gems/2.1.0/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
	from /usr/local/bin/rspec:23:in `load'
	from /usr/local/bin/rspec:23:in `<main>'
```

Выполнение тестирования после слияния
-------

На примере ветки `rspec-update` репозитория `fibertool/russian_central_bank`:
```
$ rspec

Randomized with seed 58808
........

Finished in 0.04601 seconds (files took 0.9802 seconds to load)
8 examples, 0 failures

Randomized with seed 58808
``` 