### PR TITLE
fix rates_expired? method

### DIFF
--- a/lib/russian_central_bank.rb
+++ b/lib/russian_central_bank.rb
@@ -40,7 +40,7 @@ class Money
       end
 
       def rates_expired?
-        rates_expired_at && rates_expired_at <= Time.now
+        rates_expired_at.nil? ? true : rates_expired_at <= Time.now
       end
 
       private


### PR DESCRIPTION
When rates_expired_at is a nil, rate_expired? return nil that equalent to false. 
```
/home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/money-6.11.3/lib/money/rates_store/memory.rb:57:in `block in get_rate': stack level too deep (SystemStackError)
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/money-6.11.3/lib/money/rates_store/memory.rb:71:in `block in transaction'
from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/money-6.11.3/lib/money/rates_store/memory.rb:69:in `synchronize'
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/money-6.11.3/lib/money/rates_store/memory.rb:69:in `transaction'
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/money-6.11.3/lib/money/rates_store/memory.rb:57:in `get_rate'
from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/money-6.11.3/lib/money/bank/variable_exchange.rb:193:in `get_rate'
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/russian_central_bank-1.0.0/lib/russian_central_bank.rb:33:in `get_rate'
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/russian_central_bank-1.0.0/lib/russian_central_bank.rb:57:in `indirect_rate'
from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/russian_central_bank-1.0.0/lib/russian_central_bank.rb:33:in `get_rate'
	 ... 10069 levels...
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/russian_central_bank-1.0.0/lib/russian_central_bank.rb:33:in `get_rate'
	from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/russian_central_bank-1.0.0/lib/russian_central_bank.rb:57:in `indirect_rate'
from /home/user/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/russian_central_bank-1.0.0/lib/russian_central_bank.rb:33:in `get_rate'
```