### PR TITLE
Fixed SystemStackError

### DIFF
--- a/lib/money/bank/russian_central_bank.rb
+++ b/lib/money/bank/russian_central_bank.rb
@@ -60,8 +60,11 @@ class Money
       end
 
       def indirect_rate(from, to)
-        rate = original_get_rate('RUB', to).to_f / original_get_rate('RUB', from).to_f
-        rate.nan? || !!rate.infinite? ? nil : rate
+        dividend = original_get_rate('RUB', to)
+        divider = original_get_rate('RUB', from)
+        return nil if dividend.nil? || divider.nil?
+
+        dividend.to_f / divider.to_f
       end
 
       def local_currencies

--- a/lib/money/bank/russian_central_bank.rb
+++ b/lib/money/bank/russian_central_bank.rb
@@ -62,9 +62,7 @@ class Money
       def indirect_rate(from, to)
         dividend = original_get_rate('RUB', to)
         divider = original_get_rate('RUB', from)
-        return nil if dividend.nil? || divider.nil?
-
-        dividend.to_f / divider.to_f
+        dividend && divider && dividend.to_f / divider.to_f
       end
 
       def local_currencies

--- a/lib/money/bank/russian_central_bank.rb
+++ b/lib/money/bank/russian_central_bank.rb
@@ -24,6 +24,8 @@ class Money
         super(to, from, 1.0 / rate)
       end
 
+      alias original_get_rate get_rate
+
       def get_rate(from, to)
         update_rates if rates_expired?
         super || indirect_rate(from, to)
@@ -58,7 +60,8 @@ class Money
       end
 
       def indirect_rate(from, to)
-        get_rate('RUB', to) / get_rate('RUB', from)
+        rate = original_get_rate('RUB', to).to_f / original_get_rate('RUB', from).to_f
+        rate.nan? || !!rate.infinite? ? nil : rate
       end
 
       def local_currencies

--- a/spec/lib/money/bank/russian_central_bank_spec.rb
+++ b/spec/lib/money/bank/russian_central_bank_spec.rb
@@ -111,12 +111,15 @@ describe Money::Bank::RussianCentralBank do
   end
 
   describe '#indirect_rate' do
-    before do
-      bank.flush_rates
-    end
+    context 'without rates' do
+      before do
+        bank.flush_rates
+      end
 
-    it 'should return nil when indirect rate cannot be calculated' do
-      expect(bank.send(:indirect_rate, 'RUB', 'RUB')).to be_nil
+      it 'should return nil when indirect rate cannot be calculated' do
+        expect(bank.send(:indirect_rate, 'RUB', 'RUB')).to be_nil
+        expect(bank.send(:indirect_rate, 'USD', 'AED')).to be_nil
+      end
     end
   end
 end

--- a/spec/lib/money/bank/russian_central_bank_spec.rb
+++ b/spec/lib/money/bank/russian_central_bank_spec.rb
@@ -109,4 +109,14 @@ describe Money::Bank::RussianCentralBank do
       end
     end
   end
+
+  describe '#indirect_rate' do
+    before do
+      bank.flush_rates
+    end
+
+    it 'should return nil when indirect rate cannot be calculated' do
+      expect(bank.send(:indirect_rate, 'RUB', 'RUB')).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Fix: calling "indirect_rate" method when rates are not defined throws SystemStackError: stack level too deep.