### PR TITLE
Replace instance private method index with rates for #<Money::RatesStore::Memory:xxx>

### DIFF
--- a/lib/money/bank/russian_central_bank.rb
+++ b/lib/money/bank/russian_central_bank.rb
@@ -15,7 +15,7 @@ class Money
           @rates_updated_at = Time.now
           @rates_updated_on = date
           update_expired_at
-          store.send(:index)
+          store.send(:rates)
         end
       end
 

--- a/spec/lib/money/bank/russian_central_bank_spec.rb
+++ b/spec/lib/money/bank/russian_central_bank_spec.rb
@@ -34,7 +34,7 @@ describe Money::Bank::RussianCentralBank do
     it 'should delete all rates' do
       bank.get_rate('RUB', 'USD')
       bank.flush_rates
-      expect(bank.store.send(:index)).to be_empty
+      expect(bank.store.send(:rates)).to be_empty
     end
   end
 


### PR DESCRIPTION
Replace instance private method index with rates for #<Money::RatesStore::Memory:xxx> after updating money gem to 6.13.6
https://github.com/RubyMoney/money/commit/57c3da8675948b53a1605fc1a1eccbaa460d9599